### PR TITLE
Update File.php

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -18,7 +18,7 @@ class File implements ArrayAccess, MediaUrlResolvable
 
     public function getPathAttribute()
     {
-        return $this->attributes['path'];
+        return $this->attributes['path'] ?? null;  
     }
 
     public function __debugInfo()


### PR DESCRIPTION
Blockbuilder might provide an empty array or nil, if one then tries to access path an ErrorException will be thrown.
If path is missing return null instead.